### PR TITLE
Upgrade z_mergetoaddress to take an extra prameter for utxo size

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4357,12 +4357,12 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
             CAmount nValue = out.tx->vout[out.i].nValue;
 
             if (maximum_utxo_size != 0) {
-              printf("maximum utxo size = %ld \n", maximum_utxo_size);
+              //printf("maximum utxo size = %ld \n", maximum_utxo_size);
               if (nValue > maximum_utxo_size) {
                 printf("nValue = %ld which is over maximum size so we will ignore it!\n", nValue);
                 continue;
               } else {
-                if (out.tx->vout[out.i].scriptPubKey.size() != 35) {
+                if (out.tx->vout[out.i].scriptPubKey.size() = 35) {
                   printf("utxo is an iguana utxo so we will ingore it!\n");
                   continue;
                 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4286,7 +4286,7 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
 
     CAmount maximum_utxo_size;
     if (params.size() > 5) {
-      maximum_utxo_size = params[5].get_real();
+      maximum_utxo_size = AmountFromValue( params[5] );
       printf("maximum utxo size = %ld\n", maximum_utxo_size);
       if (maximum_utxo_size < 10) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Maximum size must be bigger than 10 satoshies.");

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4298,7 +4298,7 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
 
     CAmount maximum_utxo_size;
     if (params.size() > 6) {
-      maximum_utxo_size = params[6].get_int()
+      maximum_utxo_size = params[6].get_int();
       printf("maximum utxo size = %ld\n", maximum_utxo_size);
       if (maximum_utxo_size < 10) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Maximum size must be bigger than 10 satoshies.");

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4362,7 +4362,7 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
                 printf("nValue = %ld which is over maximum size so we will ignore it!\n", nValue);
                 continue;
               } else {
-                if (out.tx->vout[out.i].scriptPubKey.size() = 35) {
+                if (out.tx->vout[out.i].scriptPubKey.size() == 35) {
                   printf("utxo is an iguana utxo so we will ingore it!\n");
                   continue;
                 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4296,7 +4296,7 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
         }
     }
 
-    CAmount maximum_utxo_size
+    CAmount maximum_utxo_size;
     if (params.size() > 6) {
       maximum_utxo_size = params[6].get_int()
       printf("maximum utxo size = %ld\n", maximum_utxo_size);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4362,7 +4362,7 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
                 printf("nValue = %ld which is over maximum size so we will ignore it!\n", nValue);
                 continue;
               } else {
-                printf("utxo found under maximum size so we will add it!\n", );
+                printf("utxo found under maximum size so we will add it!\n");
               }
             }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4296,10 +4296,10 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
         }
     }
 
-    std::int maximum_utxo_size
+    CAmount maximum_utxo_size
     if (params.size() > 6) {
       maximum_utxo_size = params[6].get_int()
-      printf("maximum utxo size = %d\n", maximum_utxo_size);
+      printf("maximum utxo size = %ld\n", maximum_utxo_size);
       if (maximum_utxo_size < 10) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Maximum size must be bigger than 10 satoshies.");
       }
@@ -4357,7 +4357,7 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
 
             if (maximum_utxo_size != 0) {
               printf("maximum utxo size = %d \n", maximum_utxo_size);
-              printf("nValue = %lld\n", nValue);
+              printf("nValue = %ld\n", nValue);
             }
 
             if (!maxedOutUTXOsFlag) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4296,6 +4296,7 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
         }
     }
 
+    std::int maximum_utxo_size
     if (params.size() > 6) {
       maximum_utxo_size = params[6].get_int()
       printf("maximum utxo size = %d\n", maximum_utxo_size);
@@ -4356,7 +4357,7 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
 
             if (maximum_utxo_size != 0) {
               printf("maximum utxo size = %d \n", maximum_utxo_size);
-              printf("nValue = %s\n", nValue);
+              printf("nValue = %lld\n", nValue);
             }
 
             if (!maxedOutUTXOsFlag) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4429,7 +4429,7 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
     #endif
 
 
-    if (numUtxos == 0 && numNotes == 0) {
+    if (numUtxos > 2 && numNotes == 0) {
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Could not find any funds to merge.");
     }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4356,7 +4356,7 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
             CAmount nValue = out.tx->vout[out.i].nValue;
 
             if (maximum_utxo_size != 0) {
-              printf("maximum utxo size = %d \n", maximum_utxo_size);
+              printf("maximum utxo size = %ld \n", maximum_utxo_size);
               printf("nValue = %ld\n", nValue);
             }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4362,7 +4362,11 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
                 printf("nValue = %ld which is over maximum size so we will ignore it!\n", nValue);
                 continue;
               } else {
-                printf("utxo found under maximum size so we will add it!\n");
+                if (out.tx->vout[out.i].scriptPubKey.size() != 35) {
+                  printf("utxo is an iguana utxo so we will ingore it!\n");
+                  continue;
+                }
+                printf("utxo found under maximum size that is not p2pk so we will add it!\n");
               }
             }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4352,21 +4352,19 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
                 continue;
             }
 
-            utxoCounter++;
             CAmount nValue = out.tx->vout[out.i].nValue;
 
             if (maximum_utxo_size != 0) {
-              //printf("maximum utxo size = %ld \n", maximum_utxo_size);
               if (nValue > maximum_utxo_size) {
-                printf("nValue = %ld which is over maximum size so we will ignore it!\n", nValue);
                 continue;
               } else {
                 if (out.tx->vout[out.i].scriptPubKey.size() == 35) {
-                  printf("utxo is an iguana utxo so we will ingore it!\n");
                   continue;
                 }
               }
             }
+
+            utxoCounter++;
 
             if (!maxedOutUTXOsFlag) {
                 CBitcoinAddress ba(address);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4164,7 +4164,7 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
             + strprintf("%d", MERGE_TO_ADDRESS_DEFAULT_TRANSPARENT_LIMIT) + ") Limit on the maximum number of UTXOs to merge.  Set to 0 to use node option -mempooltxinputlimit.\n"
             "4. shielded_limit        (numeric, optional, default="
             + strprintf("%d", MERGE_TO_ADDRESS_DEFAULT_SHIELDED_LIMIT) + ") Limit on the maximum number of notes to merge.  Set to 0 to merge as many as will fit in the transaction.\n"
-            "5. maximum_utxo_size       (int, optional) eg, 10000 anything under 10000 satoshies will be merged.\n"
+            "5. maximum_utxo_size       (numeric, optional) eg, 0.0001 anything under 10000 satoshies will be merged.\n"
             "6. \"memo\"                (string, optional) Encoded as hex. When toaddress is a z-addr, this will be stored in the memo field of the new note.\n"
 
             "\nResult:\n"
@@ -4289,7 +4289,7 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
       maximum_utxo_size = AmountFromValue( params[5] );
       printf("maximum utxo size = %ld\n", maximum_utxo_size);
       if (maximum_utxo_size < 10) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Maximum size must be bigger than 10 satoshies.");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Maximum size must be bigger than 0.00000010.");
       }
     } else {
       maximum_utxo_size = 0;
@@ -4358,7 +4358,12 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
 
             if (maximum_utxo_size != 0) {
               printf("maximum utxo size = %ld \n", maximum_utxo_size);
-              printf("nValue = %ld\n", nValue);
+              if (nValue > maximum_utxo_size) {
+                printf("nValue = %ld which is over maximum size so we will ignore it!\n", nValue);
+                continue;
+              } else {
+                printf("utxo found under maximum size so we will add it!\n", );
+              }
             }
 
             if (!maxedOutUTXOsFlag) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4164,7 +4164,7 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
             + strprintf("%d", MERGE_TO_ADDRESS_DEFAULT_TRANSPARENT_LIMIT) + ") Limit on the maximum number of UTXOs to merge.  Set to 0 to use node option -mempooltxinputlimit.\n"
             "4. shielded_limit        (numeric, optional, default="
             + strprintf("%d", MERGE_TO_ADDRESS_DEFAULT_SHIELDED_LIMIT) + ") Limit on the maximum number of notes to merge.  Set to 0 to merge as many as will fit in the transaction.\n"
-            "5. maximum_utxo_size       (numeric, optional) eg, 0.0001 anything under 10000 satoshies will be merged.\n"
+            "5. maximum_utxo_size       (numeric, optional) eg, 0.0001 anything under 10000 satoshies will be merged, ignores p2pk utxo!\n"
             "6. \"memo\"                (string, optional) Encoded as hex. When toaddress is a z-addr, this will be stored in the memo field of the new note.\n"
 
             "\nResult:\n"
@@ -4287,7 +4287,6 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
     CAmount maximum_utxo_size;
     if (params.size() > 5) {
       maximum_utxo_size = AmountFromValue( params[5] );
-      printf("maximum utxo size = %ld\n", maximum_utxo_size);
       if (maximum_utxo_size < 10) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Maximum size must be bigger than 0.00000010.");
       }
@@ -4366,7 +4365,6 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
                   printf("utxo is an iguana utxo so we will ingore it!\n");
                   continue;
                 }
-                printf("utxo found under maximum size that is not p2pk so we will add it!\n");
               }
             }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4286,7 +4286,7 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
 
     CAmount maximum_utxo_size;
     if (params.size() > 5) {
-      maximum_utxo_size = params[5].get_int();
+      maximum_utxo_size = params[5].get_real();
       printf("maximum utxo size = %ld\n", maximum_utxo_size);
       if (maximum_utxo_size < 10) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Maximum size must be bigger than 10 satoshies.");

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4429,7 +4429,7 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
     #endif
 
 
-    if (numUtxos > 2 && numNotes == 0) {
+    if (numUtxos < 2 && numNotes == 0) {
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Could not find any funds to merge.");
     }
 


### PR DESCRIPTION
This PR adds a new option to z_mergetoaddress that takes a minimum utxo size as an optional input. Using this will take any utxo under this size that is not an iguana utxo. This is to mitigate dwy attacks on KMD notary nodes. 